### PR TITLE
remove doublequotes from basedir instead of escaping

### DIFF
--- a/menu/setup/ds
+++ b/menu/setup/ds
@@ -88,9 +88,9 @@ EOF
 	[[ -f "$CONFIG" ]] || cat > "$CONFIG" << EOF
 # $ME configuration
 DIR_PRJS=\"\$HOME/Projects\"
-DIR_BASE=$HOME/.config/dev-scripts
+DIR_BASE=\$HOME/.config/dev-scripts
 CONFIG=\"$DIR_BASE/dev-scripts.conf\"
-DIR_CFG=\"\$DIR_BASE/prjs\"
+DIR_CFG=\$DIR_BASE/prjs
 DIR_OUT=\"\$HOME/data/out\"
 EOF
 	source "$CONFIG"

--- a/menu/setup/ds
+++ b/menu/setup/ds
@@ -88,7 +88,7 @@ EOF
 	[[ -f "$CONFIG" ]] || cat > "$CONFIG" << EOF
 # $ME configuration
 DIR_PRJS=\"\$HOME/Projects\"
-DIR_BASE=\"\$HOME/.config/dev-scripts\"
+DIR_BASE=$HOME/.config/dev-scripts
 CONFIG=\"$DIR_BASE/dev-scripts.conf\"
 DIR_CFG=\"\$DIR_BASE/prjs\"
 DIR_OUT=\"\$HOME/data/out\"


### PR DESCRIPTION
BASE_DIR seems to be escaped too much.
the error leading to this commit was:
/usr/share/dev-scripts/menu/setup/ds: line 124: "/home/vagrant/.config/dev-scripts"/git.conf: No such file or directory
so this removes the doublequotes but leaves $HOME intact
